### PR TITLE
More retries and request error metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
-FROM golang:1.12
-COPY . /go/src/github.com/wish/aws-asg-exporter/
+FROM golang:1.13
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/wish/aws-asg-exporter
+
+# Cache dependencies
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+COPY . /go/src/github.com/wish/aws-asg-exporter/
 RUN CGO_ENABLED=0 GOOS=linux go build -o exporter -a -installsuffix cgo .
-
-
 
 FROM alpine:3.7
 RUN apk --no-cache add ca-certificates

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,8 @@ module github.com/wish/aws-asg-exporter
 go 1.12
 
 require (
-	github.com/aws/aws-sdk-go v1.23.10
+	github.com/aws/aws-sdk-go v1.25.38
+	github.com/davecgh/go-spew v1.1.1
 	github.com/golang/protobuf v1.3.1 // indirect
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/aws/aws-sdk-go v1.23.10 h1:8um3hX3G8nfDNVHy+v3fxcUXlWJmYXFKBVWJkgCQSUQ=
 github.com/aws/aws-sdk-go v1.23.10/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.25.38 h1:QfclT79PFWCyaPDq9+zTEWsOMDWFswTpP9i07YxqPf0=
+github.com/aws/aws-sdk-go v1.25.38/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -17,8 +19,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910 h1:idejC8f05m9MGOsuEi1ATq9shN03HrxNkD/luQvxCv8=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
+github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 h1:gQz4mCbXsO+nc9n1hCxHcGA3Zx3Eo+UHZoInFGUIXNM=
 github.com/prometheus/common v0.0.0-20181126121408-4724e9255275 h1:PnBWHBf+6L0jOqq0gIVUe6Yk0/QMZ640k6NvkxcBf+8=
 github.com/prometheus/common v0.0.0-20181126121408-4724e9255275/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
+github.com/prometheus/common v0.7.0 h1:L+1lyG48J1zAQXA3RBX/nG/B3gjlHq0zTt2tlbJLyCY=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ func loopUpdateCache() {
 			}
 		}
 		globalCache = &cache{
-			Date:    t,
+			Date:    time.Now(),
 			Metrics: data,
 		}
 		mu.Unlock()


### PR DESCRIPTION
This does a few things:

- Creates the client only once.
- Much less aggressive retry behaviour. It will now retry with exponential backoff for 9 as opposed to 3 times, with a minimum 1 second wait (increasing exponentially to several minutes). New scrape requests won't trigger more requests either, because:
- Metric generation is now done in a loop on a separate thread.
- If requests, or parsing the result fails, a new metric, `aws_asg_request_error_count` is returned
- If the age of the data is higher than the TTL, the exporter will clear it after reading, to avoid repeatedly returning stale data.