### PR TITLE
Update AWS SDK session created to NewSession

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -61,7 +61,7 @@ func NewClient(opts *AWSOps) *AWSClient {
 		}
 	}
 
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	svc.Client.Retryer = client.DefaultRetryer{
 		NumMaxRetries:    9,
 		MinRetryDelay:    1 * time.Second,


### PR DESCRIPTION
Updating session created from deprecated 'New' function to 'NewSession'.
This is to support IRSA, since the older 'New' function does not
properly look for the projected token volume.